### PR TITLE
Ensure build workflow triggers after release workflow

### DIFF
--- a/.github/workflows/build_unix.yaml
+++ b/.github/workflows/build_unix.yaml
@@ -3,10 +3,16 @@ name: Build Native
 on:
   release:
     types: [created, published]
+  workflow_run:
+    workflows:
+      - New cloudflared Release
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- add workflow_run trigger to the Build Native workflow so it runs after the scheduled release workflow completes
- guard the build job so it only runs when the release workflow finished successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69043dc8fd708325b471d516f475ec49