### PR TITLE
Streamline hourly release polling

### DIFF
--- a/.github/workflows/build_unix.yaml
+++ b/.github/workflows/build_unix.yaml
@@ -3,10 +3,16 @@ name: Build Native
 on:
   release:
     types: [created, published]
+  workflow_run:
+    workflows:
+      - New cloudflared Release
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/update-cloudflared.yml
+++ b/.github/workflows/update-cloudflared.yml
@@ -6,44 +6,78 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Get latest upstream release info
+        id: upstream_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data } = await github.rest.repos.getLatestRelease({
+              owner: 'cloudflare',
+              repo: 'cloudflared'
+            });
+            core.setOutput('tag_name', data.tag_name);
+            core.setOutput('name', data.name ?? data.tag_name);
+
+      - name: Get latest release in this repo (if any)
+        id: current_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            try {
+              const { data } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              core.setOutput('tag_name', data.tag_name);
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('No existing release found in this repository.');
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Decide whether an update is required
+        id: update_guard
+        env:
+          UPSTREAM_TAG: ${{ steps.upstream_release.outputs.tag_name }}
+          UPSTREAM_TITLE: ${{ steps.upstream_release.outputs.name }}
+          CURRENT_TAG: ${{ steps.current_release.outputs.tag_name }}
+        run: |
+          if [ -z "${UPSTREAM_TAG}" ]; then
+            echo "Failed to determine upstream tag" >&2
+            exit 1
+          fi
+
+          if [ "${UPSTREAM_TAG}" = "${CURRENT_TAG}" ]; then
+            echo 'needs_update=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "needs_update=true" >> "$GITHUB_OUTPUT"
+          echo "TAG=${UPSTREAM_TAG}" >> "$GITHUB_ENV"
+          echo "TITLE=${UPSTREAM_TITLE}" >> "$GITHUB_ENV"
+
       - name: Checkout customizations branch
+        if: steps.update_guard.outputs.needs_update == 'true'
         uses: actions/checkout@v4
         with:
           ref: customizations
           fetch-depth: 0
 
-      - name: Get latest upstream release info
-        id: get_release
-        run: |
-          echo 'Fetching latest release tag from cloudflare/cloudflared...'
-          release=$(curl -s https://api.github.com/repos/cloudflare/cloudflared/releases/latest)
-          tag=$(echo "$release" | jq -r .tag_name)
-          title=$(echo "$release" | jq -r .name)
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-          echo "title=$title" >> $GITHUB_OUTPUT
-          echo "TAG=$tag" >> $GITHUB_ENV
-          echo "TITLE=$title" >> $GITHUB_ENV
-
-      - name: Check if already up-to-date
-        id: check_version
-        run: |
-          last=$(git tag --sort=-creatordate | head -n1 )
-          echo "current=$last" >> $GITHUB_OUTPUT
-          if [ "$last" = "${{ env.TAG }}" ]; then
-            echo 'up_to_date=true' >> $GITHUB_OUTPUT
-          else
-            echo 'up_to_date=false' >> $GITHUB_OUTPUT
-          fi
-
       - name: Prepare release branch
-        if: steps.check_version.outputs.up_to_date == 'false'
+        if: steps.update_guard.outputs.needs_update == 'true'
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
@@ -77,7 +111,7 @@ jobs:
           git push --force-with-lease origin "${branch}"
 
       - name: Create GitHub Release
-        if: steps.check_version.outputs.up_to_date == 'false'
+        if: steps.update_guard.outputs.needs_update == 'true'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.TAG }}


### PR DESCRIPTION
## Summary
- adjust the release workflow to poll hourly with concurrency control and GitHub API-backed checks
- skip checkout and release preparation when already at the latest upstream tag so hourly runs stay lightweight

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_69043dc8fd708325b471d516f475ec49