### PR TITLE
fix(build): use ruby34 for NetBSD; ruby32 dropped from pkgsrc repo

### DIFF
--- a/.github/workflows/build_unix.yaml
+++ b/.github/workflows/build_unix.yaml
@@ -123,9 +123,9 @@ jobs:
             export PKG_PATH
             pkg_add -U pkgin pkg_alternatives
             pkgin update
-            pkgin -y install gmake sudo bash git go golangci-lint curl wget fakeroot libffi ruby32 
+            pkgin -y install gmake sudo bash git go golangci-lint curl wget fakeroot libffi ruby34
             pkg_alternatives rebuild
-            gem install fpm
+            gem34 install fpm
             git config --global --add safe.directory /home/runner/work/cloudflared/cloudflared
           run: |
             # Do NOT run `go mod tidy` here — it sees only the current GOOS's


### PR DESCRIPTION
## What

Switch the NetBSD release job's Ruby package from `ruby32` to `ruby34`, and invoke the versioned `gem34` instead of a bare `gem`.

```diff
-            pkgin -y install ... fakeroot libffi ruby32 
+            pkgin -y install ... fakeroot libffi ruby34
             pkg_alternatives rebuild
-            gem install fpm
+            gem34 install fpm
```

## Why

Yesterday's release build failed on the NetBSD step ([run 30012854213](https://github.com/kjake/cloudflared/actions/runs/30012854213)). NetBSD 10's pkgsrc binary repository no longer ships `ruby32`:

```
ruby32 is not available in the repository
```

`pkgin` installed every other package and just skipped Ruby, so the next line — `gem install fpm` — ran with no `gem` binary and the step exited 1 (`ssh exited with code 1`). The repo now carries `ruby33`, `ruby34`, and `ruby40` (verified against the live `x86_64/10.0/All` index); `ruby34` (3.4.9) is the natural pick because it matches OpenBSD's `ruby-34` and the Ruby 3.4 FreeBSD already pulls via `rubygem-fpm`. Using `gem34` explicitly also removes the dependency on `pkg_alternatives` wiring up a generic `gem` symlink — the same pattern the OpenBSD job already uses.

## Scope

**NetBSD only.** FreeBSD (`rubygem-fpm`) and OpenBSD (`ruby-34`) use valid package names and were unchanged. Their logs show `The operation was canceled` solely because the fail-fast matrix killed them once NetBSD failed — they were not broken on their own merits.

## Test plan

- [x] YAML parses cleanly (ruby `YAML.load_file`)
- [x] Confirmed `ruby34` exists in `cdn.netbsd.org/.../NetBSD/x86_64/10.0/All`; no `ruby32` remains in the repo
- [ ] Re-run the Build Native workflow and confirm the NetBSD job installs Ruby, `gem34 install fpm` succeeds, and `gmake cloudflared` produces the `cloudflared-netbsd10-amd64` asset

## Note (out of scope)

`fpm` is only used by the Makefile's packaging function (`Makefile:207`), not the `cloudflared:` binary target these jobs actually run, so Ruby/fpm are effectively unused in all three BSD `prepare` blocks. Left as-is here to keep the fix surgical; can be pruned in a follow-up if desired.