### PR TITLE
fix(build): define createTokenFile for BSD/generic service build

### DIFF
--- a/.github/workflows/update-cloudflared.yml
+++ b/.github/workflows/update-cloudflared.yml
@@ -110,6 +110,7 @@ jobs:
           # 4) Re-apply BSD-portability file overlays (these shims rarely drift in upstream)
           rm -rf .github/workflows
           git checkout origin/customizations -- \
+            cmd/cloudflared/generic_service.go \
             diagnostic/network/collector_unix_test.go \
             diagnostic/network/collector_unix.go \
             diagnostic/system_collector_unix.go \

--- a/cmd/cloudflared/generic_service.go
+++ b/cmd/cloudflared/generic_service.go
@@ -11,6 +11,15 @@ import (
 	"github.com/cloudflare/cloudflared/cmd/cloudflared/cliutil"
 )
 
+// OS-specific function for token file creation.
+//
+// common_service.go (built on every platform) references createTokenFile
+// unconditionally. Upstream defines it in the linux/darwin/windows service
+// files but not in the generic build, so BSD targets (freebsd/netbsd/openbsd)
+// fail with "undefined: createTokenFile". createTokenFileUnix is declared in
+// common_service.go, so alias it here exactly as macOS and Linux do.
+var createTokenFile = createTokenFileUnix
+
 func runApp(app *cli.App, graceShutdownC chan struct{}) {
 	app.Commands = append(app.Commands, &cli.Command{
 		Name:  "service",


### PR DESCRIPTION
## What

Two changes that make BSD release builds compile and keep them compiling:

1. **`cmd/cloudflared/generic_service.go`** — add `var createTokenFile = createTokenFileUnix`.
2. **`.github/workflows/update-cloudflared.yml`** — pin `cmd/cloudflared/generic_service.go` into the deterministic step-4 overlay list.

## Why

After the NetBSD packaging fix (#12), all three BSDs got past `pkgin`/`gem` and reached `go build`, where they hit a **pre-existing, upstream** compile error that the earlier failure had masked:

```
cmd/cloudflared/common_service.go:56:12: undefined: createTokenFile
```

`common_service.go` (no build tag → compiled on every GOOS) calls `createTokenFile` unconditionally. Upstream defines it in the three tier-1 service files but not the generic fallback:

| file | build tag | defines `createTokenFile`? |
|------|-----------|:--:|
| `common_service.go` | *(none)* | defines `createTokenFileUnix` |
| `linux_service.go` | `linux` | ✅ `= createTokenFileUnix` |
| `macos_service.go` | `darwin` | ✅ `= createTokenFileUnix` |
| `windows_service.go` | `windows` | ✅ native func |
| `generic_service.go` | `!windows && !darwin && !linux` | ❌ **missing** |

FreeBSD/NetBSD/OpenBSD all compile the generic file, so all three fail to link. The fix mirrors `linux_service.go` and `macos_service.go` byte-for-byte; `createTokenFileUnix` is in `common_service.go` (compiled on BSD), so it resolves with **no duplicate** on the tier-1 platforms.

## Why the workflow change

`update-cloudflared.yml` regenerates each `release-*` branch from upstream, then re-applies fork files. The fork owns `generic_service.go` as a whole-file replacement, but it was reaching release branches only through the `git merge origin/customizations || true` step — not the deterministic step-4 overlay. A future upstream edit to that file could leave merge conflict markers and silently rebreak every BSD build. Adding it to the overlay list makes the fork's copy authoritative, exactly like the other BSD-portability shims.

## Verification

- Symbol / build-tag partition verified by hand (Go not available in the authoring env): for `GOOS=freebsd|netbsd|openbsd` exactly one `createTokenFile` is active (the generic alias); tier-1 platforms are unaffected.
- YAML validates.
- [ ] Confirmed green by a `build_unix.yaml` run once `release-*` carries the fix (see note below).

## Note on the current release

`release-2026.7.3` already exists with the broken source and does **not** auto-regenerate (the updater only rebuilds on a new upstream tag). It is being unblocked by committing the fixed `generic_service.go` onto that branch directly and re-dispatching the build. This PR ensures **future** releases carry the fix automatically.