### PR TITLE
fix(build): stamp release tag into BSD binary version

### DIFF
--- a/.github/workflows/build_unix.yaml
+++ b/.github/workflows/build_unix.yaml
@@ -106,7 +106,11 @@ jobs:
             # Upstream's vendor tree is already complete; trust it.
             go mod download
             go install golang.org/x/tools/cmd/goimports@latest
-            gmake cloudflared
+            # Stamp the release tag into the binary (main.Version). The build
+            # runs while the GitHub release is still a draft, so the git tag
+            # does not exist yet and the Makefile's `git describe` would fall
+            # back to a bare commit SHA. Passing VERSION explicitly overrides it.
+            gmake cloudflared VERSION="${{ steps.get_release.outputs.tag_name }}"
 
       # Build step for NetBSD
       - name: Build from Source on NetBSD
@@ -134,7 +138,11 @@ jobs:
             # Upstream's vendor tree is already complete; trust it.
             go mod download
             go install golang.org/x/tools/cmd/goimports@latest
-            gmake cloudflared
+            # Stamp the release tag into the binary (main.Version). The build
+            # runs while the GitHub release is still a draft, so the git tag
+            # does not exist yet and the Makefile's `git describe` would fall
+            # back to a bare commit SHA. Passing VERSION explicitly overrides it.
+            gmake cloudflared VERSION="${{ steps.get_release.outputs.tag_name }}"
 
       # Build step for OpenBSD
       - name: Build from Source on OpenBSD
@@ -156,7 +164,11 @@ jobs:
             # Upstream's vendor tree is already complete; trust it.
             go mod download
             go install golang.org/x/tools/cmd/goimports@latest
-            gmake cloudflared
+            # Stamp the release tag into the binary (main.Version). The build
+            # runs while the GitHub release is still a draft, so the git tag
+            # does not exist yet and the Makefile's `git describe` would fall
+            # back to a bare commit SHA. Passing VERSION explicitly overrides it.
+            gmake cloudflared VERSION="${{ steps.get_release.outputs.tag_name }}"
 
       - name: Authenticate GH CLI
         run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token


### PR DESCRIPTION
## What

Pass `VERSION="<release tag>"` to `gmake cloudflared` in all three BSD build steps, so the binary's `main.Version` is the real release version instead of a git commit SHA.

## Why

`cloudflared --version` on the BSD builds was reporting a bare SHA:

```
cloudflared version a83dfa20 (built 2026-07-24-1718 UTC)
```

instead of the release version, so a user can't tell which release they're running. Older releases were correct:

```
cloudflared version 2025.9.1 (built 2025-09-22-1419 UTC)
```

### Root cause

The Makefile derives the version from git:

```make
VERSION := $(shell git describe --tags --always --match "[0-9][0-9][0-9][0-9].*.*")
```

`build_unix.yaml` builds the binaries while the GitHub release is still a **draft**. The `<tag>` git tag isn't created until the *publish* step, which runs *after* the build — so at build time `git describe` finds no matching tag and falls back (`--always`) to the short commit SHA. Nothing in the Makefile changed; the pipeline's draft→build→publish ordering is what regressed this versus older releases that were built with the tag already present.

### Fix

A command-line `VERSION=` overrides the Makefile's `:=` assignment in GNU make, so the git-describe fallback is bypassed entirely and the binary is stamped deterministically — independent of whether the tag exists yet. Uses the same `${{ steps.get_release.outputs.tag_name }}` that the "Upload build to GitHub Release" step already uses inline.

## Test plan

- [x] YAML validates; all three build steps stamp `VERSION`.
- [ ] Re-dispatch `build_unix.yaml` for `2026.7.3` and confirm `cloudflared --version` reports `2026.7.3` (this PR is used to re-release the current binaries).