### PR TITLE
ci(build): add FreeBSD 15.1 & NetBSD 11.0 legs; bump OpenBSD to 7.9

### DIFF
--- a/.github/workflows/build_unix.yaml
+++ b/.github/workflows/build_unix.yaml
@@ -22,13 +22,28 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Don't let one leg's failure cancel the others — a new/older OS version
+      # breaking must not stop the proven ones from building and uploading.
+      fail-fast: false
       matrix:
         include:
+          # FreeBSD: keep 14.x and track 15.x (OPNsense 25.7+ is FreeBSD 15).
           - os: freebsd
+            release: "14.3"
             assetName: cloudflared-freebsd14-amd64
+          - os: freebsd
+            release: "15.1"
+            assetName: cloudflared-freebsd15-amd64
+          # NetBSD: keep 10.x and add 11.0.
           - os: netbsd
+            release: "10.1"
             assetName: cloudflared-netbsd10-amd64
+          - os: netbsd
+            release: "11.0"
+            assetName: cloudflared-netbsd11-amd64
+          # OpenBSD: single latest release.
           - os: openbsd
+            release: "7.9"
             assetName: cloudflared-openbsd7-amd64
     env:
       GOEXPERIMENT: "noboringcrypto"
@@ -76,7 +91,7 @@ jobs:
         if: matrix.os == 'freebsd'
         uses: vmactions/freebsd-vm@v1
         with:
-          release: "14.3"
+          release: "${{ matrix.release }}"
           envs: "GOEXPERIMENT CGO_ENABLED GOTOOLCHAIN"
           usesh: true
           mem: 4096
@@ -117,7 +132,7 @@ jobs:
         if: matrix.os == 'netbsd'
         uses: vmactions/netbsd-vm@v1
         with:
-          release: "10.1"
+          release: "${{ matrix.release }}"
           envs: "GOEXPERIMENT CGO_ENABLED GOTOOLCHAIN"
           usesh: true
           mem: 4096
@@ -149,7 +164,7 @@ jobs:
         if: matrix.os == 'openbsd'
         uses: vmactions/openbsd-vm@v1
         with:
-          release: "7.8"
+          release: "${{ matrix.release }}"
           envs: "GOEXPERIMENT CGO_ENABLED GOTOOLCHAIN"
           usesh: true
           mem: 4096

--- a/.github/workflows/build_unix.yaml
+++ b/.github/workflows/build_unix.yaml
@@ -169,8 +169,12 @@ jobs:
           usesh: true
           mem: 4096
           prepare: |
-            pkg_add -xaz gmake sudo-- bash git go curl wget libffi ruby-34
-            gem34 install fpm
+            # cloudflared's build target only runs `gmake cloudflared` and never
+            # invokes fpm, so ruby/gem are intentionally omitted. On OpenBSD 7.9
+            # ruby 4.0 became the default and `pkg_add ruby-34` fuzzy-matched to
+            # ruby-4.0 (which ships gem40, not gem34), breaking the leg; dropping
+            # the unused ruby/fpm install removes that version-drift failure mode.
+            pkg_add -xaz gmake sudo-- bash git go curl wget
             git config --global --add safe.directory /home/runner/work/cloudflared/cloudflared
           run: |
             # Do NOT run `go mod tidy` here — it sees only the current GOOS's


### PR DESCRIPTION
## What

Expands the native BSD build matrix from 3 legs to 5:

| OS | release | asset | change |
|---|---|---|---|
| FreeBSD | 14.3 | cloudflared-freebsd14-amd64 | kept |
| FreeBSD | **15.1** | **cloudflared-freebsd15-amd64** | **new** (OPNsense 25.7+ is FreeBSD 15) |
| NetBSD | 10.1 | cloudflared-netbsd10-amd64 | kept |
| NetBSD | **11.0** | **cloudflared-netbsd11-amd64** | **new** |
| OpenBSD | **7.9** | cloudflared-openbsd7-amd64 | **bumped** from 7.8 (asset name unchanged) |

The `release:` value is now parameterized per matrix entry (`${{ matrix.release }}`) so a single OS can build multiple versions, and `fail-fast: false` ensures one leg failing can't cancel the proven ones.

## Why

OPNsense's current release is built on FreeBSD 15.1, so a matching `freebsd15` binary keeps in-sync while `freebsd14` continues to support older installs as long as possible. (These are static `CGO_ENABLED=0` Go binaries, so the 14 build likely already runs on 15 — this is explicit version-sync + future-proofing.)

## Verification (before adding — to avoid another failed release)

- **vmactions VM images**: confirmed `conf/15.1.conf`, `conf/11.0.conf`, `conf/7.9.conf` all exist in the respective `vmactions/*-vm` actions (the authoritative source; the `-builder` release assets lag and are not it).
- **NetBSD 11.0 pkgsrc** (highest risk — brand-new major): `x86_64/11.0/All` has 27,462 packages including `ruby34-3.4.9nb2` and `go-1.26.5`, plus every other dep the prepare step installs.
- **OpenBSD 7.9**: amd64 packages include `ruby-3.4.9p1` and `go-1.26.2`.
- **FreeBSD 15.1**: official per-release pkg repo; identical install list to the working 14.3 leg.

## Test plan

- [ ] Dispatch `build_unix.yaml` for a tag and confirm all 5 legs go green and upload their assets (used here to re-release 2026.8.0 with the freebsd15/netbsd11 binaries).