### PR TITLE
docs(readme): record FreeBSD 15.1 & NetBSD 11.0 targets; OpenBSD 7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Upstream is polled every 12 hours; a new upstream release produces a matching re
 
 | OS      | Version | Architecture | Asset                         |
 | ------- | ------- | ------------ | ----------------------------- |
-| FreeBSD | 14      | amd64        | `cloudflared-freebsd14-amd64` |
-| OpenBSD | 7       | amd64        | `cloudflared-openbsd7-amd64`  |
-| NetBSD  | 10      | amd64        | `cloudflared-netbsd10-amd64`  |
+| FreeBSD | 14.3    | amd64        | `cloudflared-freebsd14-amd64` |
+| FreeBSD | 15.1    | amd64        | `cloudflared-freebsd15-amd64` |
+| OpenBSD | 7.9     | amd64        | `cloudflared-openbsd7-amd64`  |
+| NetBSD  | 10.1    | amd64        | `cloudflared-netbsd10-amd64`  |
+| NetBSD  | 11.0    | amd64        | `cloudflared-netbsd11-amd64`  |
 
 See [Build provenance](#build-provenance) at the bottom for binary metadata.
 


### PR DESCRIPTION
Updates the **Supported targets** table to reflect the expanded build matrix (merged in #15): adds FreeBSD 15.1 (`cloudflared-freebsd15-amd64`) and NetBSD 11.0 (`cloudflared-netbsd11-amd64`), and shows OpenBSD at 7.9. Versions are listed as the actual build-host release so the table matches the build-provenance note that points here.

Docs-only; no code or workflow changes.