### PR TITLE
build(ci): bump FreeBSD 14 leg to 14.4; update README

### DIFF
--- a/.github/workflows/build_unix.yaml
+++ b/.github/workflows/build_unix.yaml
@@ -29,7 +29,7 @@ jobs:
         include:
           # FreeBSD: keep 14.x and track 15.x (OPNsense 25.7+ is FreeBSD 15).
           - os: freebsd
-            release: "14.3"
+            release: "14.4"
             assetName: cloudflared-freebsd14-amd64
           - os: freebsd
             release: "15.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Upstream is polled every 12 hours; a new upstream release produces a matching re
 
 | OS      | Version | Architecture | Asset                         |
 | ------- | ------- | ------------ | ----------------------------- |
-| FreeBSD | 14.3    | amd64        | `cloudflared-freebsd14-amd64` |
+| FreeBSD | 14.4    | amd64        | `cloudflared-freebsd14-amd64` |
 | FreeBSD | 15.1    | amd64        | `cloudflared-freebsd15-amd64` |
 | OpenBSD | 7.9     | amd64        | `cloudflared-openbsd7-amd64`  |
 | NetBSD  | 10.1    | amd64        | `cloudflared-netbsd10-amd64`  |


### PR DESCRIPTION
Moves the FreeBSD-14 build leg from 14.3 to 14.4 (vmactions ships `conf/14.4.conf`) and updates the README Supported targets row. Asset name `cloudflared-freebsd14-amd64` is unchanged; the other four legs are untouched.

In line with today's version updates (#15 added FreeBSD 15.1 / NetBSD 11.0, bumped OpenBSD 7.9).